### PR TITLE
[codex] Adapt SeaBlock startup for Bob and Angel dev

### DIFF
--- a/SeaBlock/control.lua
+++ b/SeaBlock/control.lua
@@ -13,7 +13,7 @@ function seablock.create_rock_chest(surface, pos)
   local has_items = false
 
   if storage.starting_items and (not game.is_multiplayer()) then
-    for item, quantity in pairs(storage.starting_items) do
+    for _, quantity in pairs(storage.starting_items) do
       if quantity > 0 then
         has_items = true
         break
@@ -62,9 +62,18 @@ local function init()
       remote.call("freeplay", "set_disable_crashsite", true)
     end
   end
+  -- The 2.0 branch is moving these startup steps to research triggers.  Until
+  -- that conversion removes this runtime table entirely, only include the
+  -- optional SCT lab technology when it actually exists so the no-SCT target
+  -- does not advertise an impossible scripted unlock.
+  local circuit_board_unlocks = { "sb-startup3" }
+  if prototypes.technology["sct-lab-t1"] then
+    table.insert(circuit_board_unlocks, "sct-lab-t1")
+  end
+
   storage.unlocks = {
     ["angels-ore3-crushed"] = { "sb-startup1", "angels-bio-wood-processing" },
-    ["bob-basic-circuit-board"] = { "sb-startup3", "sct-lab-t1" },
+    ["bob-basic-circuit-board"] = circuit_board_unlocks,
   }
   if prototypes.technology["automation-science-pack"] then
     storage.unlocks["lab"] = { "automation-science-pack" }
@@ -150,7 +159,7 @@ end)
 
 script.on_init(init)
 
-script.on_configuration_changed(function(cfg)
+script.on_configuration_changed(function(_cfg)
   init()
   -- Heavy handed fix for mods that forget migration scripts
   for _, force in pairs(game.forces) do
@@ -158,7 +167,7 @@ script.on_configuration_changed(function(cfg)
     force.reset_recipes()
     for tech_name, tech in pairs(force.technologies) do
       if tech.researched then
-        for tech_name, effect in pairs(tech.prototype.effects) do
+        for _, effect in pairs(tech.prototype.effects) do
           if effect.type == "unlock-recipe" then
             force.recipes[effect.recipe].enabled = true
           end
@@ -177,7 +186,9 @@ script.on_configuration_changed(function(cfg)
       and force.technologies["sb-startup4"]
       and force.technologies["sb-startup4"].researched
     then
-      force.technologies["sct-lab-t1"].researched = true
+      if force.technologies["sct-lab-t1"] then
+        force.technologies["sct-lab-t1"].researched = true
+      end
       force.technologies["automation-science-pack"].researched = true
     end
   end

--- a/SeaBlock/data-final-fixes.lua
+++ b/SeaBlock/data-final-fixes.lua
@@ -87,6 +87,11 @@ end
 if mods["bobplates"] and mods["angelspetrochem"] then
   local OV = angelsmods.functions.OV
 
-  OV.global_replace_item("bob-carbon", "angels-solid-carbon")
+  -- Angel's carbon replacement now happens in data-updates, but recipes from
+  -- Sea Block or optional mods can still be edited afterward.  Bob's current
+  -- dev branch uses "carbon" rather than the legacy "bob-carbon" name, so keep
+  -- this final pass aligned with the new prototype while preserving the intent:
+  -- Sea Block should expose Angel's carbon solid, not Bob's standalone carbon.
+  OV.global_replace_item("carbon", "angels-solid-carbon")
   OV.execute()
 end

--- a/SeaBlock/data-final-fixes/tech-tree.lua
+++ b/SeaBlock/data-final-fixes/tech-tree.lua
@@ -14,6 +14,32 @@ seablock.lib.hide_technology("bob-electrolysis-2")
 seablock.lib.hide_technology("bob-chemical-processing-1")
 seablock.lib.hide_technology("bob-chemical-processing-2")
 
+-- Bob dev still leaves some visible progression technologies pointing at old
+-- Bob metal-processing gates that Sea Block hides or empties in favour of
+-- Angel's smelting chains.  Replace those prerequisite leaks with reachable
+-- Angel material milestones so later science tiers do not depend on hidden,
+-- disabled Bob technologies that the player can never research directly.
+local zinc_prerequisite_replacements = {
+  "angels-advanced-chemistry-2",
+  "angels-bio-desert-farm",
+  "angels-bio-refugium-puffer-1",
+  "angels-bio-swamp-farm",
+  "angels-bio-temperate-farm",
+  "angels-metallurgy-3",
+  "angels-slag-processing-2",
+  "angels-water-treatment-3",
+  "automation-3",
+  "bob-electronics-machine-2",
+  "military-3",
+  "sb-bio-processing-advanced",
+}
+
+for _, tech_name in pairs(zinc_prerequisite_replacements) do
+  if data.raw.technology[tech_name] and data.raw.technology["angels-zinc-smelting-1"] then
+    bobmods.lib.tech.replace_prerequisite(tech_name, "bob-zinc-processing", "angels-zinc-smelting-1")
+  end
+end
+
 bobmods.lib.tech.remove_prerequisite("circuit-network", "angels-bio-wood-processing-2")
 bobmods.lib.tech.add_prerequisite("circuit-network", "angels-bio-paper-1")
 bobmods.lib.tech.remove_prerequisite("angels-rubbers", "circuit-network")

--- a/SeaBlock/data-updates/coal.lua
+++ b/SeaBlock/data-updates/coal.lua
@@ -7,7 +7,11 @@ if mods["bobenemies"] then
   seablock.lib.substingredient("bob-alien-explosive", "coal", "angels-wood-charcoal")
 end
 seablock.lib.substingredient("angels-filter-coal", "coal", "angels-wood-charcoal")
-seablock.lib.substingredient("bob-carbon", "coal", "angels-wood-charcoal")
+-- Bob's dev branch renamed the carbon item/recipe from "bob-carbon" to the
+-- Factorio 2.0-style "carbon".  Angel's petrochem override will later replace
+-- the recipe result with "angels-solid-carbon"; Sea Block still needs to swap
+-- the coal ingredient here so carbon production fits the no-natural-coal start.
+seablock.lib.substingredient("carbon", "coal", "angels-wood-charcoal")
 if mods["Transport_Drones"] then
   seablock.lib.substingredient("road", "coal", "angels-wood-charcoal")
 end
@@ -24,9 +28,15 @@ angelsmods.functions.move_item("angels-pellet-coke", "angels-bio-processing-wood
 data.raw.recipe["angels-pellet-coke"].localised_name = { "item-name.angels-pellet-charcoal" }
 
 -- Clear fuel value so these don't appear in Helmod's fuel picker
-data.raw.item["bob-carbon"].fuel_emissions_multiplier = nil
-data.raw.item["bob-carbon"].fuel_value = nil
-data.raw.item["bob-carbon"].fuel_category = nil
+-- The hidden Bob carbon item can remain present as "carbon" even when Angel's
+-- recipes prefer "angels-solid-carbon".  Guard the lookup so future Bob/Angel
+-- load-order changes do not turn an optional hidden item into a startup crash.
+local bob_carbon_item = data.raw.item["carbon"]
+if bob_carbon_item then
+  bob_carbon_item.fuel_emissions_multiplier = nil
+  bob_carbon_item.fuel_value = nil
+  bob_carbon_item.fuel_category = nil
+end
 data.raw.item["coal"].fuel_emissions_multiplier = nil
 data.raw.item["coal"].fuel_value = nil
 data.raw.item["coal"].fuel_category = nil

--- a/SeaBlock/data-updates/military.lua
+++ b/SeaBlock/data-updates/military.lua
@@ -982,14 +982,17 @@ if mods["bobwarfare"] then
   bobmods.lib.tech.add_new_science_pack("bob-artillery-turret-2", "production-science-pack", 1)
   bobmods.lib.tech.add_new_science_pack("bob-artillery-wagon-2", "production-science-pack", 1)
   bobmods.lib.tech.add_prerequisite("artillery", "military-3")
-  bobmods.lib.tech.add_prerequisite("artillery", "bob-cobalt-processing")
   bobmods.lib.tech.add_prerequisite("artillery", "angels-stone-smelting-2")
-  seablock.lib.substingredient("artillery-turret", "iron-gear-wheel", "bob-cobalt-steel-gear-wheel", nil)
+  -- Angel's Smelting 2.0.4 migrates old cobalt-steel gears/bearings to brass
+  -- and its Bob override swaps artillery's cobalt-steel plates to invar.  Write
+  -- the same final ingredients here so Sea Block does not reintroduce hidden
+  -- cobalt-steel intermediates after Angel's override pass.
+  seablock.lib.substingredient("artillery-turret", "iron-gear-wheel", "bob-brass-gear-wheel", nil)
   seablock.lib.substingredient("artillery-turret", "concrete", "angels-concrete-brick", nil)
-  seablock.lib.substingredient("artillery-turret", "steel-plate", "bob-cobalt-steel-alloy", nil)
-  seablock.lib.substingredient("artillery-wagon", "iron-gear-wheel", "bob-cobalt-steel-gear-wheel", nil)
+  seablock.lib.substingredient("artillery-turret", "steel-plate", "bob-invar-alloy", nil)
+  seablock.lib.substingredient("artillery-wagon", "iron-gear-wheel", "bob-brass-gear-wheel", nil)
   seablock.lib.substingredient("artillery-wagon", "pipe", "bob-brass-pipe", nil)
-  seablock.lib.substingredient("artillery-wagon", "steel-plate", "bob-cobalt-steel-alloy", nil)
+  seablock.lib.substingredient("artillery-wagon", "steel-plate", "bob-invar-alloy", nil)
 
   bobmods.lib.tech.add_prerequisite("artillery", "bob-radar-3")
 

--- a/SeaBlock/data-updates/misc.lua
+++ b/SeaBlock/data-updates/misc.lua
@@ -155,7 +155,10 @@ end
 
 -- Buff bob's silicon and tungsten recipes
 seablock.lib.substingredient("bob-silicon-carbide", "bob-silicon-powder", nil, 10)
-seablock.lib.substingredient("bob-silicon-carbide", "bob-carbon", nil, 10)
+-- Angel's Bob-plates override executes before Sea Block data-updates and
+-- replaces Bob's dev-branch "carbon" ingredient with Angel's carbon solid.
+-- Adjust the post-replacement ingredient so the recipe buff still applies.
+seablock.lib.substingredient("bob-silicon-carbide", "angels-solid-carbon", nil, 10)
 data.raw.recipe["bob-silicon-carbide"].results[1].amount = 20
 
 seablock.lib.substingredient("bob-silicon-nitride", "bob-silicon-powder", nil, 10)
@@ -163,14 +166,9 @@ seablock.lib.substingredient("bob-silicon-nitride", "angels-gas-nitrogen", nil, 
 data.raw.recipe["bob-silicon-nitride"].results[1].amount = 10
 
 seablock.lib.substingredient("bob-tungsten-carbide", "bob-tungsten-oxide", nil, 10)
-seablock.lib.substingredient("bob-tungsten-carbide", "bob-carbon", nil, 10)
+seablock.lib.substingredient("bob-tungsten-carbide", "angels-solid-carbon", nil, 10)
 seablock.lib.substresult("bob-tungsten-carbide", "bob-tungsten-carbide", nil, 20)
 bobmods.lib.recipe.set_energy_required("bob-tungsten-carbide", 6)
-
-seablock.lib.substingredient("bob-tungsten-carbide-2", "bob-powdered-tungsten", nil, 10)
-seablock.lib.substingredient("bob-tungsten-carbide-2", "bob-carbon", nil, 10)
-seablock.lib.substresult("bob-tungsten-carbide-2", "bob-tungsten-carbide", nil, 20)
-bobmods.lib.recipe.set_energy_required("bob-tungsten-carbide-2", 6)
 
 seablock.lib.substingredient("bob-copper-tungsten-alloy", "bob-powdered-tungsten", nil, 15)
 seablock.lib.substingredient("bob-copper-tungsten-alloy", "copper-plate", "angels-powder-copper", 10)

--- a/SeaBlock/data-updates/startup.lua
+++ b/SeaBlock/data-updates/startup.lua
@@ -5,6 +5,8 @@
 -- Offshore pump  2              1                     10
 -- Crystallizer   5                                                           5
 
+-- luacheck: globals table.deepcopy
+
 local knowningredients = {
   ["angels-electrolyser"] = {
     { "iron-plate", 10 },
@@ -85,30 +87,47 @@ for k, v in pairs(knowningredients) do
 end
 
 -- unlock lab and optional components with Basic Circuit Board
-if data.raw.technology["sct-lab-t1"] then
+local sct_lab_tech = data.raw.technology["sct-lab-t1"]
+if sct_lab_tech then
   bobmods.lib.tech.add_prerequisite("sct-lab-t1", "sb-startup3")
 else
+  -- Without Science Cost Tweaker there is no intermediate lab technology.
+  -- Unlock the vanilla lab from Sea Block's circuit-board startup milestone so
+  -- the later automation-science trigger can still be driven by crafting a lab.
   bobmods.lib.tech.add_recipe_unlock("sb-startup3", "lab")
   bobmods.lib.recipe.enabled("lab", false)
 end
 
 if data.raw.technology["automation-science-pack"] then
-  bobmods.lib.tech.add_prerequisite("automation-science-pack", "sct-lab-t1")
+  -- Science Cost Tweaker inserts "sct-lab-t1" between basic circuits and red
+  -- science.  The non-SCT target set used for the Factorio 2.0 port does not
+  -- have that technology, so wire red science to the startup milestone that
+  -- unlocks the lab recipe instead of indexing a missing SCT prototype.
+  local lab_prerequisite = sct_lab_tech and "sct-lab-t1" or "sb-startup3"
+  -- This trigger technology is part of Sea Block's startup chain.  Keep its
+  -- prerequisite list to the single lab milestone selected above so the
+  -- no-SCT branch behaves like the SCT branch without adding a removed
+  -- optional technology.
+  data.raw.technology["automation-science-pack"].prerequisites = { lab_prerequisite }
 
   data.raw.technology["automation-science-pack"].research_trigger = { type = "craft-item", item = "lab" }
   data.raw.technology["automation-science-pack"].unit = nil
-  data.raw.technology["sct-lab-t1"].unit = {
-    count = 1,
-    ingredients = {},
-    time = 1,
-  }
+  if sct_lab_tech then
+    sct_lab_tech.unit = {
+      count = 1,
+      ingredients = {},
+      time = 1,
+    }
+  end
   seablock.lib.hide_technology("sb-startup4")
 end
 
-bobmods.lib.tech.remove_prerequisite("sct-lab-t1", "steam-power")
+if sct_lab_tech then
+  bobmods.lib.tech.remove_prerequisite("sct-lab-t1", "steam-power")
+end
 
 local movedrecipes = table.deepcopy(seablock.startup_recipes)
-for k, v in pairs(seablock.scripted_techs) do
+for k in pairs(seablock.scripted_techs) do
   if data.raw.technology[k] then
     for _, effect in pairs(data.raw.technology[k].effects or {}) do
       movedrecipes[effect.recipe] = true
@@ -135,7 +154,7 @@ local function consumes_startup_item(recipe)
     ["copper-cable"] = true,
     ["stone-furnace"] = true,
   }
-  for k, v in pairs(recipe.ingredients or {}) do
+  for _, v in pairs(recipe.ingredients or {}) do
     if ironnames[v.name] then
       found = true
       break

--- a/SeaBlock/starting-items.lua
+++ b/SeaBlock/starting-items.lua
@@ -1,14 +1,31 @@
 seablock = seablock or {}
 
 function seablock.populate_starting_items(items)
+  -- Bob Logistics dev migrated its stone pipes back into the base pipe names,
+  -- while older Sea Block/Bob combinations may still expose Bob or Angel stone
+  -- pipe prototypes.  Keep the base pipe starter stack below, but resolve the
+  -- extra stone-pipe starter stack against whichever prototype actually loaded.
+  -- This prevents the scripted first-hour bootstrap from granting removed items.
+  local extra_pipe = "pipe"
+  if items["angels-stone-pipe"] then
+    extra_pipe = "angels-stone-pipe"
+  elseif items["bob-stone-pipe"] then
+    extra_pipe = "bob-stone-pipe"
+  end
+
+  local extra_pipe_to_ground = "pipe-to-ground"
+  if items["angels-stone-pipe-to-ground"] then
+    extra_pipe_to_ground = "angels-stone-pipe-to-ground"
+  elseif items["bob-stone-pipe-to-ground"] then
+    extra_pipe_to_ground = "bob-stone-pipe-to-ground"
+  end
+
   local starting_items = {
     ["stone"] = 130,
     ["small-electric-pole"] = 50,
     ["small-lamp"] = 12,
     ["iron-plate"] = 1200,
     ["bob-basic-circuit-board"] = 200,
-    ["bob-stone-pipe"] = 100,
-    ["bob-stone-pipe-to-ground"] = 50,
     ["stone-brick"] = 500,
     ["pipe"] = 21,
     ["bob-copper-pipe"] = 5,
@@ -16,6 +33,8 @@ function seablock.populate_starting_items(items)
     ["iron-stick"] = 88,
     ["pipe-to-ground"] = 2,
   }
+  starting_items[extra_pipe] = (starting_items[extra_pipe] or 0) + 100
+  starting_items[extra_pipe_to_ground] = (starting_items[extra_pipe_to_ground] or 0) + 50
 
   -- Starting power production
   if items["wind-turbine-2"] then


### PR DESCRIPTION
Hi! This is a Codex-assisted compatibility pass for the SeaBlock 2.0 logic branch against Angel dev and Bob dev. Use any or all of it if it helps.

What changed:
- Updates SeaBlock carbon references for Bob dev, where the old `bob-carbon` prototype is now `carbon`, while preserving Angel petrochem's `angels-solid-carbon` replacement.
- Guards optional Science Cost Tweaker paths so the non-SCT Factorio 2.0 target can load and progress without referencing absent `sct-lab-t1` prototypes.
- Keeps the temporary runtime startup unlock table from advertising absent SCT technologies, with an inline note that the branch is moving toward trigger techs.
- Removes obsolete `bob-tungsten-carbide-2` adjustments, since that recipe was removed upstream.
- Resolves starter stone pipe stacks against the loaded Bob/Angel/base pipe prototypes.
- Replaces visible hidden Bob zinc-processing prerequisite leaks with reachable Angel smelting milestones.
- Aligns SeaBlock artillery overrides with Angel's Smelting 2.0.4 cobalt-steel-intermediate migration by writing brass gears and invar alloy directly instead of reintroducing old hidden cobalt-steel gears.

Review feedback addressed:
- Removed the Bob burner-phase rationale; SeaBlock forces that setting off, so the comment was misleading.
- Removed the `bob-tungsten-carbide-2` edits.
- Reworked the scripted-tech touch to be a minimal temporary no-SCT guard and explicitly notes the trigger-tech direction instead of expanding that system.

Validation:
- Angel dev updated from `f9006cfd` to `300bcd55` before the latest compatibility check.
- Factorio headless 2.0.76 startup passed with Quality and Elevated Rails enabled and Space Age disabled: `runs/20260601-120837/factorio-startup.log`.
- Data dump confirms `artillery-turret` / `artillery-wagon` use brass gears and invar alloy, and no visible recipe consumes old cobalt-steel gear/bearing intermediates.
- Earlier full-path checks on this PR branch also passed: early-game smoke `runs/20260601-014732-early-game/factorio-benchmark.log`, rocket-launch smoke `runs/20260601-014803-rocket-launch/factorio-benchmark.log`.
- Focused Lua quality passed on touched files: `luac -p`, `luacheck`, and lizard all clean with no warnings or threshold hits.

Generated with help from Codex. Thanks again for all the work on this branch.
