### PR TITLE
Update Bob tungsten references

### DIFF
--- a/SeaBlock/data-updates/building-prerequisites.lua
+++ b/SeaBlock/data-updates/building-prerequisites.lua
@@ -56,7 +56,7 @@ bobmods.lib.tech.add_prerequisite("angels-slag-processing-3", "angels-stone-smel
 bobmods.lib.tech.add_prerequisite("angels-water-treatment-4", "angels-stone-smelting-3")
 
 -- Copper tungsten / tungsten carbide prerequisites
-bobmods.lib.tech.add_prerequisite("angels-ore-processing-5", "bob-tungsten-alloy-processing")
+bobmods.lib.tech.add_prerequisite("angels-ore-processing-5", "bob-tungsten-processing")
 
 -- Nitinol prerequisites
 bobmods.lib.tech.add_prerequisite("angels-ore-processing-5", "bob-nitinol-processing")

--- a/SeaBlock/data-updates/misc.lua
+++ b/SeaBlock/data-updates/misc.lua
@@ -162,21 +162,16 @@ seablock.lib.substingredient("bob-silicon-nitride", "bob-silicon-powder", nil, 1
 seablock.lib.substingredient("bob-silicon-nitride", "angels-gas-nitrogen", nil, 130)
 data.raw.recipe["bob-silicon-nitride"].results[1].amount = 10
 
-seablock.lib.substingredient("bob-tungsten-carbide", "bob-tungsten-oxide", nil, 10)
-seablock.lib.substingredient("bob-tungsten-carbide", "carbon", nil, 10)
-seablock.lib.substresult("bob-tungsten-carbide", "bob-tungsten-carbide", nil, 20)
-bobmods.lib.recipe.set_energy_required("bob-tungsten-carbide", 6)
-
-seablock.lib.substingredient("bob-tungsten-carbide-2", "bob-powdered-tungsten", nil, 10)
-seablock.lib.substingredient("bob-tungsten-carbide-2", "carbon", nil, 10)
-seablock.lib.substresult("bob-tungsten-carbide-2", "bob-tungsten-carbide", nil, 20)
-bobmods.lib.recipe.set_energy_required("bob-tungsten-carbide-2", 6)
+seablock.lib.substingredient("tungsten-carbide", "bob-tungsten-oxide", nil, 10)
+seablock.lib.substingredient("tungsten-carbide", "carbon", nil, 10)
+seablock.lib.substresult("tungsten-carbide", "tungsten-carbide", nil, 20)
+bobmods.lib.recipe.set_energy_required("tungsten-carbide", 6)
 
 seablock.lib.substingredient("bob-copper-tungsten-alloy", "bob-powdered-tungsten", nil, 15)
 seablock.lib.substingredient("bob-copper-tungsten-alloy", "copper-plate", "angels-powder-copper", 10)
 seablock.lib.substresult("bob-copper-tungsten-alloy", "bob-copper-tungsten-alloy", nil, 25)
 bobmods.lib.recipe.set_energy_required("bob-copper-tungsten-alloy", 8)
-bobmods.lib.tech.add_prerequisite("bob-tungsten-alloy-processing", "angels-copper-smelting-2")
+bobmods.lib.tech.add_prerequisite("bob-tungsten-processing", "angels-copper-smelting-2")
 
 -- Other prerequisites
 if data.raw.technology["bob-electronics-machine-1"] then


### PR DESCRIPTION
This retargets the earlier material rename work to `2.0-logic-changes` and narrows it to the part still needed there.

What changed:
- Updates SeaBlock tungsten carbide recipe adjustments to the current Bob Mods dev prototype names: `tungsten-carbide` and `bob-tungsten-processing`.
- Leaves carbon alone because `2.0-logic-changes` already contains the `bob-carbon` to `carbon` cleanup.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Checked Bob Mods `dev` prototypes for the current tungsten carbide item/recipe and tungsten processing technology names.
- Kept the branch to direct substitutions only, with no defensive guards around required dependency data.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.