### PR TITLE
Handle startup lab tech without SCT

### DIFF
--- a/SeaBlock/data-updates/startup.lua
+++ b/SeaBlock/data-updates/startup.lua
@@ -87,25 +87,26 @@ end
 -- unlock lab and optional components with Basic Circuit Board
 if data.raw.technology["sct-lab-t1"] then
   bobmods.lib.tech.add_prerequisite("sct-lab-t1", "sb-startup3")
+  bobmods.lib.tech.remove_prerequisite("sct-lab-t1", "steam-power")
 else
   bobmods.lib.tech.add_recipe_unlock("sb-startup3", "lab")
   bobmods.lib.recipe.enabled("lab", false)
 end
 
 if data.raw.technology["automation-science-pack"] then
-  bobmods.lib.tech.add_prerequisite("automation-science-pack", "sct-lab-t1")
-
+  bobmods.lib.tech.remove_prerequisite("automation-science-pack", "steam-power")
   data.raw.technology["automation-science-pack"].research_trigger = { type = "craft-item", item = "lab" }
   data.raw.technology["automation-science-pack"].unit = nil
-  data.raw.technology["sct-lab-t1"].unit = {
-    count = 1,
-    ingredients = {},
-    time = 1,
-  }
-  seablock.lib.hide_technology("sb-startup4")
+  if data.raw.technology["sct-lab-t1"] then
+    bobmods.lib.tech.add_prerequisite("automation-science-pack", "sct-lab-t1")
+    data.raw.technology["sct-lab-t1"].unit = {
+      count = 1,
+      ingredients = {},
+      time = 1,
+    }
+    seablock.lib.hide_technology("sb-startup4")
+  end
 end
-
-bobmods.lib.tech.remove_prerequisite("sct-lab-t1", "steam-power")
 
 local movedrecipes = table.deepcopy(seablock.startup_recipes)
 for k, v in pairs(seablock.scripted_techs) do


### PR DESCRIPTION
This retargets the startup work to `2.0-logic-changes`. The old dead crushed-smelting unlock removal is already present on that branch, so this PR now contains the remaining small startup fix found while validating the corrected 2.0 stack.

What changed:
- Handles the startup lab path when `ScienceCostTweakerM` is not loaded and `sct-lab-t1` does not exist.
- Converts `automation-science-pack` to the intended lab craft trigger without requiring `sct-lab-t1`.
- Keeps the SCT-specific prerequisite and one-tick unit adjustment inside the `sct-lab-t1` existence path.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Ran the local aggregate smoke stack; the current 2.0 target failed first on missing `sct-lab-t1`, then on a `steam-power` / `automation-science-pack` cycle.
- Kept the fix to the startup technology path only, rather than bundling unrelated warning cleanup.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.