### PR TITLE
Replace hidden nickel in Bob Power recipes

### DIFF
--- a/SeaBlock/data-updates/unobtainable-items.lua
+++ b/SeaBlock/data-updates/unobtainable-items.lua
@@ -122,6 +122,13 @@ bobmods.lib.recipe.remove_ingredient("bob-roboport-antenna-4", "bob-nickel-plate
 seablock.lib.substingredient("bob-silver-zinc-battery", "bob-zinc-plate", "angels-solid-zinc-oxide", nil)
 seablock.lib.substingredient("angels-thorium-fuel-cell", "bob-zinc-plate", "steel-plate", nil)
 seablock.lib.substingredient("angels-deuterium-fuel-cell", "bob-zinc-plate", "steel-plate", nil)
+seablock.lib.substingredient("bob-heat-pipe-2", "bob-nickel-plate", "bob-titanium-plate", nil)
+seablock.lib.substingredient("bob-boiler-3", "bob-nickel-plate", "bob-titanium-plate", nil)
+seablock.lib.substingredient("bob-heat-exchanger-2", "bob-nickel-plate", "bob-titanium-plate", nil)
+seablock.lib.substingredient("bob-oil-boiler-2", "bob-nickel-plate", "bob-titanium-plate", nil)
+seablock.lib.substingredient("bob-burner-reactor-2", "bob-nickel-plate", "bob-titanium-plate", nil)
+seablock.lib.substingredient("bob-fluid-reactor-2", "bob-nickel-plate", "bob-titanium-plate", nil)
+seablock.lib.substingredient("bob-fluid-generator-2", "bob-nickel-plate", "bob-titanium-plate", nil)
 
 seablock.lib.unhide_recipe("angels-solid-zinc-oxide")
 bobmods.lib.tech.add_recipe_unlock("angels-zinc-smelting-2", "angels-solid-zinc-oxide")


### PR DESCRIPTION
Related issue: modded-factorio/SeaBlock#375

This retargets the hidden nickel recipe fix to `2.0-logic-changes` and replaces the earlier broad replacement approach with targeted recipe substitutions.

What changed:
- Replaces hidden `bob-nickel-plate` in the Bob Power recipes named by the issue: heat pipe 2, boiler 3, heat exchanger 2, fluid burning boiler 2, burner heat source 2, and fluid burning heat source 2.
- Also covers `bob-fluid-generator-2`, which is the same current Bob Power hidden-nickel recipe class.
- Uses existing `seablock.lib.substingredient` calls instead of a global replacement across every recipe.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Rechecked Bob Mods `dev` for current `bob-nickel-plate`, `bob-zinc-plate`, and `bob-gunmetal-alloy` references.
- Narrowed this PR to the concrete Bob Power nickel leaks from issue 375 and the same Bob Power family, in response to the review concern on the old broad approach.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.