### PR TITLE
Remove hidden electronics prerequisites

### DIFF
--- a/SeaBlock/data-final-fixes/tech-tree.lua
+++ b/SeaBlock/data-final-fixes/tech-tree.lua
@@ -64,6 +64,28 @@ bobmods.lib.tech.replace_prerequisite(
 bobmods.lib.tech.remove_prerequisite("automation-2", "electronics")
 bobmods.lib.tech.remove_prerequisite("logistics-2", "electronics")
 bobmods.lib.tech.remove_prerequisite("bob-chemical-plant", "electronics")
+for _, tech in pairs(data.raw.technology) do
+  local prerequisites = tech.prerequisites
+  if prerequisites then
+    local has_bob_electronics = false
+    for _, prerequisite in pairs(prerequisites) do
+      if prerequisite == "bob-electronics" then
+        has_bob_electronics = true
+        break
+      end
+    end
+    for i = #prerequisites, 1, -1 do
+      if prerequisites[i] == "electronics" then
+        if tech.name == "bob-electronics" or has_bob_electronics then
+          table.remove(prerequisites, i)
+        else
+          prerequisites[i] = "bob-electronics"
+          has_bob_electronics = true
+        end
+      end
+    end
+  end
+end
 
 -- repair-pack is now unlocked with military
 bobmods.lib.tech.remove_prerequisite("bob-repair-pack-2", "repair-pack")


### PR DESCRIPTION
Related issue: modded-factorio/SeaBlock#369

This retargets the hidden `electronics` prerequisite cleanup to `2.0-logic-changes`.

What changed:
- Replaces remaining hidden `electronics` prerequisites with `bob-electronics` where a visible replacement is needed.
- Removes duplicate hidden `electronics` prerequisites when the technology already depends on `bob-electronics` or is itself `bob-electronics`.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Kept this in SeaBlock final tech-tree cleanup, where the dependency technology data is loaded.
- Kept this separate from the copper-wire shortcut PR because the shortcut is a distinct player-facing unlock path.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.