### PR TITLE
Move copper wire shortcut off hidden electronics

### DIFF
--- a/SeaBlock/data-final-fixes/tech-tree.lua
+++ b/SeaBlock/data-final-fixes/tech-tree.lua
@@ -64,6 +64,7 @@ bobmods.lib.tech.replace_prerequisite(
 bobmods.lib.tech.remove_prerequisite("automation-2", "electronics")
 bobmods.lib.tech.remove_prerequisite("logistics-2", "electronics")
 bobmods.lib.tech.remove_prerequisite("bob-chemical-plant", "electronics")
+data.raw.shortcut["give-copper-wire"].technology_to_unlock = "bob-electronics"
 
 -- repair-pack is now unlocked with military
 bobmods.lib.tech.remove_prerequisite("bob-repair-pack-2", "repair-pack")


### PR DESCRIPTION
Related issue: modded-factorio/SeaBlock#365

This retargets the copper wire shortcut fix to `2.0-logic-changes`.

What changed:
- Moves the `give-copper-wire` shortcut unlock away from hidden vanilla `electronics`.
- Attaches the shortcut to the visible Bob Electronics path with `bob-electronics`.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Kept this as a one-line shortcut fix, separate from the broader hidden-prerequisite cleanup.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.