### PR TITLE
Keep placed trees and rocks deconstructable

### DIFF
--- a/SeaBlock/data-final-fixes/mapgen.lua
+++ b/SeaBlock/data-final-fixes/mapgen.lua
@@ -65,7 +65,6 @@ for k, v in pairs(data.raw.tree) do
     and k ~= "angels-puffer-nest"
   then
     v.autoplace = nil
-    seablock.lib.add_flag("tree", v.name, "not-deconstructable")
   else
     v.autoplace.control = nil
   end
@@ -74,12 +73,10 @@ end
 -- No rocks
 for _, v in pairs(data.raw["simple-entity"]) do
   v.autoplace = nil
-  seablock.lib.add_flag("simple-entity", v.name, "not-deconstructable")
 end
 
 for _, v in pairs(data.raw["optimized-decorative"]) do
   v.autoplace = nil
-  seablock.lib.add_flag("optimized-decorative", v.name, "not-deconstructable")
 end
 
 local keepcontrols = {}


### PR DESCRIPTION
Related issue: modded-factorio/SeaBlock#238

This retargets the deconstruction planner compatibility fix to `2.0-logic-changes`.

What changed:
- Stops adding `not-deconstructable` to tree, simple-entity, and decorative prototypes in the mapgen cleanup.
- Leaves the rest of the autoplace removal behavior unchanged.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Kept this branch focused on player interaction with placed trees and rocks from compatible mods.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.