### PR TITLE
Skip missing unobtainable prototypes

### DIFF
--- a/SeaBlock/data-final-fixes/unobtainable_items.lua
+++ b/SeaBlock/data-final-fixes/unobtainable_items.lua
@@ -182,7 +182,9 @@ end
 
 -- Add hidden flag to disabled items so they don't show up in circuit menu/item filter/FNEI etc.
 for k, _ in pairs(unobtainable) do
-  seablock.lib.hide_item(k)
+  if data.raw.item[k] or data.raw.fluid[k] then
+    seablock.lib.hide_item(k)
+  end
 end
 
 local keep_unobtainable_recipes = {
@@ -215,7 +217,9 @@ for recipe_name, recipe in pairs(data.raw.recipe) do
 end
 
 for k, _ in pairs(removerecipes) do
-  bobmods.lib.recipe.hide(k)
+  if data.raw.recipe[k] then
+    bobmods.lib.recipe.hide(k)
+  end
 end
 
 -- Remove disabled recipes from technology unlock


### PR DESCRIPTION
This retargets the optional unobtainable-prototype guard to `2.0-logic-changes`.

What changed:
- Skips hiding unobtainable items/fluids that are not present in the current mod set.
- Skips hiding removerecipes entries when the recipe prototype does not exist.
- Leaves existing cleanup behavior unchanged for prototypes that do exist.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Kept this limited to optional prototype presence checks in the unobtainable cleanup path.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.