### PR TITLE
Remove Bob Enemies hardened bile drops

### DIFF
--- a/SeaBlock/data-final-fixes/unobtainable_items.lua
+++ b/SeaBlock/data-final-fixes/unobtainable_items.lua
@@ -218,6 +218,34 @@ for k, _ in pairs(removerecipes) do
   bobmods.lib.recipe.hide(k)
 end
 
+local function remove_hardened_bile_effects(value)
+  if type(value) ~= "table" then
+    return false
+  end
+
+  for index = #value, 1, -1 do
+    if remove_hardened_bile_effects(value[index]) then
+      table.remove(value, index)
+    end
+  end
+  for key, child in pairs(value) do
+    if type(key) ~= "number" and remove_hardened_bile_effects(child) then
+      value[key] = nil
+    end
+  end
+
+  return value.type == "create-entity" and value.entity_name == "bob-hardened-bile"
+end
+
+if mods["bobenemies"] then
+  for _, type_name in pairs({ "stream", "turret" }) do
+    for _, prototype in pairs(data.raw[type_name] or {}) do
+      remove_hardened_bile_effects(prototype)
+    end
+  end
+  data.raw["simple-entity"]["bob-hardened-bile"].minable = nil
+end
+
 -- Remove disabled recipes from technology unlock
 for k, v in pairs(data.raw.technology) do
   if v.effects then


### PR DESCRIPTION
Related issue: modded-factorio/SeaBlock#366

This retargets the Bob Enemies hardened bile cleanup to `2.0-logic-changes`.

What changed:
- Removes nested `create-entity` effects that create `bob-hardened-bile` from Bob Enemies stream and turret prototypes.
- Makes `bob-hardened-bile` non-minable when Bob Enemies is present, so it cannot produce removed resin results.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Kept this branch limited to the hardened-bile/resin path discussed in issue 366.

Validation:
- Local pre-commit whitespace and changed Lua complexity checks passed.
- Whole-file lizard check found no threshold warnings; measured Lua functions remained A-grade.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.