### PR TITLE
Migrate Bob Greenhouse wood pellets

### DIFF
--- a/SeaBlock/migrations/SeaBlock_0.6.0.json
+++ b/SeaBlock/migrations/SeaBlock_0.6.0.json
@@ -6,13 +6,17 @@
     "item":
     [
       ["filter-charcoal", "angels-filter-charcoal"],
-      ["pellet-charcoal", "angels-pellet-charcoal"]
+      ["pellet-charcoal", "angels-pellet-charcoal"],
+      ["wood-pellets", "angels-wood-pellets"],
+      ["bob-wood-pellets", "angels-wood-pellets"]
     ],
     "recipe":
     [
       ["thermal-bore-water", "sb-thermal-bore-water"],
       ["thermal-extractor-water", "sb-thermal-extractor-water"],
-      ["crafting-handonly", "sb-crafting-handonly"]
+      ["crafting-handonly", "sb-crafting-handonly"],
+      ["wood-pellets", "angels-wood-pellets"],
+      ["bob-wood-pellets", "angels-wood-pellets"]
     ],
     "recipe-category": 
     [


### PR DESCRIPTION
Related issue: modded-factorio/SeaBlock#362

This retargets the Bob Greenhouse pellet migration fix to `2.0-logic-changes`.

What changed:
- Migrates old `wood-pellets` and `bob-wood-pellets` item names to `angels-wood-pellets`.
- Migrates the matching recipe names to `angels-wood-pellets`.

Methodology:
- Rebuilt the head branch from `KompetenzAirbag/SeaBlock:2.0-logic-changes`.
- Kept this branch to migration data only because it is a save/history fix rather than live prototype cleanup.

Validation:
- Local pre-commit whitespace check passed.
- `python3 -m json.tool SeaBlock/migrations/SeaBlock_0.6.0.json` passed.
- Local Factorio headless map creation passed on the aggregate 2.0 validation stack for minimal SeaBlock, SeaBlock + Bob Power, and SeaBlock + Bob Enemies + Bob Greenhouse with Quality and Elevated Rails enabled.
- No test files or harness changes are included in this PR.

Target branch: `2.0-logic-changes`.