### PR TITLE
Add thermal bore stateless visualisation

### DIFF
--- a/SeaBlock/data-updates/thermal-extractor.lua
+++ b/SeaBlock/data-updates/thermal-extractor.lua
@@ -115,6 +115,11 @@ bore.base_picture.sheet.repeat_count = 16
 
 -- Edit animation to include output pipe facing north and south
 local working_animation = table.deepcopy(bore.graphics_set.animation.north)
+bore.stateless_visualisation = {
+  count = 1,
+  render_layer = "object",
+  animation = table.deepcopy(working_animation),
+}
 
 --- This animation is a translation of the mining_drill but for an assembling_machine
 --- This is done because an assembling_machine has no base_picture so the northern and southern pipe extentions have to be added via animation


### PR DESCRIPTION
## Summary

Adds a `stateless_visualisation` to the repurposed Angel's thermal bore prototype. SeaBlock converts the bore from a mining drill to an assembling machine; this keeps its existing working animation available as a stateless visual layer while leaving the fixed recipe and crafting category unchanged.

## Validation

- Local SeaBlock quality gate: `git diff --check`, staged Lua complexity, and whole-branch changed Lua complexity all passed with A-grade cyclomatic complexity.
- Factorio headless smoke passed on a local validation stack that includes the pending small SeaBlock 2.0 fixes plus this commit.
- `--dump-data` positive check passed: final `assembling-machine.angels-thermal-bore` keeps `fixed_recipe = sb-thermal-bore-water` and has a one-entry `stateless_visualisation` with an animation.

Note: I kept the PR itself to just the #357 change. The clean target branch currently still has unrelated load blockers that are already covered by other pending small PRs, so the smoke/dump validation was run on the local aggregate validation stack rather than by bundling those fixes here.