### PR TITLE
Tech tree fixes

### DIFF
--- a/SeaBlock/data-final-fixes/tech-tree.lua
+++ b/SeaBlock/data-final-fixes/tech-tree.lua
@@ -79,6 +79,9 @@ bobmods.lib.tech.remove_prerequisite("plastics", "bob-chemical-plant")
 bobmods.lib.tech.hide("uranium-mining")
 bobmods.lib.tech.remove_prerequisite("uranium-processing", "uranium-mining")
 
+-- Remove production science pack dependency on gas processing
+bobmods.lib.tech.remove_prerequisite("production-science-pack", "angels-gas-processing")
+
 -- Not needed in Sea Block
 bobmods.lib.tech.remove_prerequisite("angels-bio-processing-blue", "bob-zinc-processing")
 bobmods.lib.tech.remove_prerequisite("angels-bio-processing-blue", "angels-stone-smelting-2")

--- a/SeaBlock/data-updates/building-prerequisites.lua
+++ b/SeaBlock/data-updates/building-prerequisites.lua
@@ -1,68 +1,23 @@
 -- TODO: Remove this file. Changes should now be in Angel's
 
--- Bronze prerequisites
-bobmods.lib.tech.add_prerequisite("angels-advanced-chemistry-1", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-cooling", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-bio-nutrient-paste", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-ore-floatation", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-ore-processing-1", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-powder-metallurgy-2", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-strand-casting-1", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-thermal-water-extraction", "bob-alloy-processing")
-bobmods.lib.tech.add_prerequisite("angels-water-washing-2", "bob-alloy-processing")
-
 -- Clay Brick prerequisites
+-- These changes are not yet in Angel's.
 bobmods.lib.tech.add_prerequisite("angels-advanced-ore-refining-1", "angels-stone-smelting-1")
-bobmods.lib.tech.add_prerequisite("angels-cooling", "angels-stone-smelting-1")
-bobmods.lib.tech.add_prerequisite("angels-metallurgy-2", "angels-stone-smelting-1")
 bobmods.lib.tech.add_prerequisite("fluid-handling", "angels-stone-smelting-1")
-bobmods.lib.tech.add_prerequisite("angels-gardens", "angels-stone-smelting-1")
-
--- Brass prerequisites
-bobmods.lib.tech.add_prerequisite("angels-advanced-chemistry-2", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-metallurgy-3", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("automation-3", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-bio-desert-farm", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-bio-refugium-puffer-1", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-bio-swamp-farm", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-bio-temperate-farm", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("bob-electronics-machine-2", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-slag-processing-2", "bob-zinc-processing")
-bobmods.lib.tech.add_prerequisite("angels-water-treatment-3", "bob-zinc-processing")
-
--- Concrete Brick prerequisites
-bobmods.lib.tech.add_prerequisite("angels-advanced-chemistry-2", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-metallurgy-3", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-bio-desert-farm", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-bio-swamp-farm", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-bio-temperate-farm", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-bio-refugium-hatchery", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-slag-processing-2", "angels-stone-smelting-2")
-bobmods.lib.tech.add_prerequisite("angels-water-treatment-3", "angels-stone-smelting-2")
 
 -- Titanium prerequisites
+-- These changes are not yet in Angel's.
 bobmods.lib.tech.add_prerequisite("angels-advanced-chemistry-3", "bob-titanium-processing")
-bobmods.lib.tech.add_prerequisite("angels-metallurgy-4", "bob-titanium-processing")
-bobmods.lib.tech.add_prerequisite("automation-4", "bob-titanium-processing")
-bobmods.lib.tech.add_prerequisite("angels-bio-refugium-biter-1", "bob-titanium-processing")
-bobmods.lib.tech.add_prerequisite("angels-slag-processing-3", "bob-titanium-processing")
-bobmods.lib.tech.add_prerequisite("angels-water-treatment-4", "bob-titanium-processing")
 
 -- Reinforced concrete brick
+-- These changes are not yet in Angel's.
 bobmods.lib.tech.add_prerequisite("angels-advanced-chemistry-3", "angels-stone-smelting-3")
-bobmods.lib.tech.add_prerequisite("angels-metallurgy-4", "angels-stone-smelting-3")
-bobmods.lib.tech.add_prerequisite("angels-bio-refugium-biter-1", "angels-stone-smelting-3")
-bobmods.lib.tech.add_prerequisite("angels-slag-processing-3", "angels-stone-smelting-3")
-bobmods.lib.tech.add_prerequisite("angels-water-treatment-4", "angels-stone-smelting-3")
 
 -- Copper tungsten / tungsten carbide prerequisites
+-- These changes are not yet in Angel's.
+-- Ore processing 4 already depends on tungsten processing, is this really necessary to have?
 bobmods.lib.tech.add_prerequisite("angels-ore-processing-5", "bob-tungsten-processing")
 
--- Nitinol prerequisites
-bobmods.lib.tech.add_prerequisite("angels-ore-processing-5", "bob-nitinol-processing")
-
 -- Advanced circuit
+-- These changes are not yet in Angel's.
 bobmods.lib.tech.add_prerequisite("tank", "advanced-circuit")
-
--- Processing unit
-bobmods.lib.tech.add_prerequisite("angels-bio-refugium-biter-1", "processing-unit")

--- a/SeaBlock/data-updates/military.lua
+++ b/SeaBlock/data-updates/military.lua
@@ -982,7 +982,6 @@ if mods["bobwarfare"] then
   bobmods.lib.tech.add_new_science_pack("bob-artillery-turret-2", "production-science-pack", 1)
   bobmods.lib.tech.add_new_science_pack("bob-artillery-wagon-2", "production-science-pack", 1)
   bobmods.lib.tech.add_prerequisite("artillery", "military-3")
-  bobmods.lib.tech.add_prerequisite("artillery", "bob-cobalt-processing")
   bobmods.lib.tech.add_prerequisite("artillery", "angels-stone-smelting-2")
   seablock.lib.substingredient("artillery-turret", "iron-gear-wheel", "bob-cobalt-steel-gear-wheel", nil)
   seablock.lib.substingredient("artillery-turret", "concrete", "angels-concrete-brick", nil)
@@ -990,11 +989,13 @@ if mods["bobwarfare"] then
   seablock.lib.substingredient("artillery-wagon", "iron-gear-wheel", "bob-cobalt-steel-gear-wheel", nil)
   seablock.lib.substingredient("artillery-wagon", "pipe", "bob-brass-pipe", nil)
   seablock.lib.substingredient("artillery-wagon", "steel-plate", "bob-cobalt-steel-alloy", nil)
-
   bobmods.lib.tech.add_prerequisite("artillery", "bob-radar-3")
 
   bobmods.lib.tech.add_prerequisite("spidertron", "bob-radar-5")
-
+  
+  -- Remove Military 3 dependency on zinc processing
+  bobmods.lib.tech.remove_prerequisite("military-3", "bob-zinc-processing")
+  
   -- Adjust Power Armor
   bobmods.lib.tech.remove_science_pack("power-armor", "chemical-science-pack")
   bobmods.lib.tech.add_science_pack("power-armor", "military-science-pack", 1)

--- a/SeaBlock/data-updates/other-mods.lua
+++ b/SeaBlock/data-updates/other-mods.lua
@@ -16,7 +16,7 @@ if mods["jetpack"] then
   bobmods.lib.tech.add_prerequisite("jetpack-1", "modular-armor")
   bobmods.lib.tech.add_prerequisite("jetpack-1", "angels-rocket-booster-1")
   bobmods.lib.tech.add_prerequisite("jetpack-1", "military-science-pack")
-  bobmods.lib.tech.add_prerequisite("jetpack-1", "bob-zinc-processing")
+  bobmods.lib.tech.add_prerequisite("jetpack-1", "bob-brass-processing")
   bobmods.lib.recipe.replace_ingredient("jetpack-1", "electronic-circuit", "advanced-circuit")
   bobmods.lib.recipe.replace_ingredient("jetpack-1", "pipe", "bob-brass-pipe")
   bobmods.lib.recipe.replace_ingredient("jetpack-1", "steel-plate", "bob-invar-alloy")

--- a/SeaBlock/prototypes/technology.lua
+++ b/SeaBlock/prototypes/technology.lua
@@ -53,7 +53,7 @@ data:extend({
       "angels-bio-processing-red",
       "advanced-circuit",
       "angels-stone-smelting-2",
-      "bob-zinc-processing",
+      "bob-brass-processing",
       "chemical-science-pack",
     },
     effects = {


### PR DESCRIPTION
Fixed that some techs were dependent on hidden techs so they were not unlockable.
- Purple science no longer depends on gas processing.
- Removed unnecessary code from building-prerequisites.lua, solving the issue of many post-blue science techs depending on zinc processing.
- Artillery no longer depends on cobalt processing.
- Military 3 no longer depends on zinc processing.
- Jetpack (from Earendel's Jetpack mod) depends on brass processing instead of zinc processing.
- Advanced algae processing depends on brass processing instead of zinc processing.